### PR TITLE
Feat graphsolver

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod app;
 mod nodes;
 mod pins;
 mod shapes;
+mod solver;
 mod viewer;
 
 const NUMBER_COLOR: egui::Color32 = egui::Color32::from_rgb(255, 255, 0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod nodes;
 mod pins;
 mod shapes;
 mod solver;
+mod values;
 mod viewer;
 
 const NUMBER_COLOR: egui::Color32 = egui::Color32::from_rgb(255, 255, 0);

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -2,7 +2,7 @@ use egui::Ui;
 use egui_snarl::{ui::PinInfo, InPin, OutPin, Snarl};
 
 use crate::{
-    pins::{IPin, InputPin, OPin, OutputPinId},
+    pins::{IPin, InputPin, InputPinId, OPin, OutputPinId},
     shapes::Shapes,
 };
 
@@ -35,8 +35,45 @@ impl Nodes {
     /// Recalculate all outputs of the node
     /// and mark all it's inputs as clean
     pub fn solve(&mut self) {
-        todo!()
+        match self {
+            Nodes::ConstantValueNode(_) => todo!(),
+            Nodes::Sink(_) => todo!(),
+            Nodes::Range(node) => (),
+            Nodes::Point(node) => node.recalc(),
+            Nodes::Circle(_) => todo!(),
+            Nodes::Canvas(_) => todo!(),
+            Nodes::RepeatShape(_) => todo!(),
+        }
     }
+
+    pub fn push_inputs(&mut self, id: InputPinId, inputs: &crate::values::Values) {
+        match self {
+            Nodes::ConstantValueNode(_) => todo!(),
+            Nodes::Sink(_) => todo!(),
+            Nodes::Range(_) => todo!(),
+            Nodes::Point(node) => node.values_in(id, inputs),
+            Nodes::Circle(_) => todo!(),
+            Nodes::Canvas(_) => todo!(),
+            Nodes::RepeatShape(_) => todo!(),
+        }
+    }
+
+    pub fn values_out(&self, id: OutputPinId) -> crate::values::Values {
+        match self {
+            Nodes::ConstantValueNode(_) => todo!(),
+            Nodes::Sink(_) => todo!(),
+            Nodes::Range(node) => node.values_out(),
+            Nodes::Point(_) => todo!(),
+            Nodes::Circle(_) => todo!(),
+            Nodes::Canvas(_) => todo!(),
+            Nodes::RepeatShape(_) => todo!(),
+        }
+    }
+
+    /// TODO: This won't work, as both self and other are stored
+    /// in the same backing storage, so we can't have two references
+    /// inside easily...
+    pub fn pipe_into(&self, out_id: OutputPinId, other: &mut Self, in_id: InputPinId) {}
 
     /// PinIds are just raw indices, not uuids, so we can
     /// just enumerate the count :)

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -282,6 +282,13 @@ impl Nodes {
             _ => None,
         }
     }
+
+    pub fn try_get_points(&self) -> Option<Vec<piet::kurbo::Point>> {
+        match self {
+            Self::Point(node) => Some(node.points_out().map(|pt| *pt).collect::<Vec<_>>()),
+            _ => None,
+        }
+    }
 }
 
 /// General info for a node, every [`Node`] implementor

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -2,7 +2,7 @@ use egui::Ui;
 use egui_snarl::{ui::PinInfo, InPin, OutPin, Snarl};
 
 use crate::{
-    pins::{IPin, InputPin, OPin},
+    pins::{IPin, InputPin, OPin, OutputPinId},
     shapes::Shapes,
 };
 
@@ -29,6 +29,16 @@ pub enum Nodes {
     Circle(circle::CircleNode),
     Canvas(canvas::CanvasNode),
     RepeatShape(repeat::RepeatShapeNode),
+}
+
+impl Nodes {
+    pub fn solve(&mut self) {
+        todo!()
+    }
+
+    pub fn out_ids(&self) -> impl Iterator<Item = OutputPinId> {
+        (0..1).into_iter().map(|_| OutputPinId(0))
+    }
 }
 pub fn format_float(value: f64) -> String {
     let value = (value * 1000.0).round() / 1000.0;

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -32,14 +32,16 @@ pub enum Nodes {
 }
 
 impl Nodes {
+    /// Recalculate all outputs of the node
+    /// and mark all it's inputs as clean
     pub fn solve(&mut self) {
         todo!()
     }
 
-    /// TODO: How to impl this? Do we store the ids on the nodes
-    /// themselves?
+    /// PinIds are just raw indices, not uuids, so we can
+    /// just enumerate the count :)
     pub fn out_ids(&self) -> impl Iterator<Item = OutputPinId> {
-        (0..1).into_iter().map(|_| OutputPinId(0))
+        (0..self.outputs()).into_iter().map(|n| OutputPinId(n))
     }
 }
 pub fn format_float(value: f64) -> String {

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -36,6 +36,8 @@ impl Nodes {
         todo!()
     }
 
+    /// TODO: How to impl this? Do we store the ids on the nodes
+    /// themselves?
     pub fn out_ids(&self) -> impl Iterator<Item = OutputPinId> {
         (0..1).into_iter().map(|_| OutputPinId(0))
     }

--- a/src/nodes/point.rs
+++ b/src/nodes/point.rs
@@ -1,6 +1,9 @@
 use egui_snarl::ui::PinInfo;
 
-use crate::pins::{IPin, InputPin, InputPinId, OPin, OutputPin};
+use crate::{
+    pins::{IPin, InputPin, InputPinId, OPin, OutputPin},
+    values::Values,
+};
 
 use super::NodeInfo;
 
@@ -19,10 +22,8 @@ impl PointNode {
             .iter()
             .zip(y.iter())
             .map(|(x, y)| piet::kurbo::Point::new(*x, *y));
-        self.point_out.values_in(pts);
-    }
-    fn needs_recalc(&self) -> bool {
-        self.x_in.is_dirty() || self.y_in.is_dirty()
+        self.point_out.values_in(pts.clone());
+        println!("Solved points: {:?}", pts);
     }
     pub fn point_out(&self) -> piet::kurbo::Point {
         self.point_out.value_out().map(|pt| *pt).unwrap_or_default()
@@ -48,6 +49,9 @@ impl PointNode {
             crate::values::Values::Float(values) => pin.values_in(values.iter().map(|v| *v)),
             _ => unreachable!(),
         }
+    }
+    pub fn values_out(&self) -> Values {
+        Values::Point(self.point_out.values_out().clone())
     }
 }
 

--- a/src/nodes/point.rs
+++ b/src/nodes/point.rs
@@ -32,26 +32,12 @@ impl PointNode {
         self.point_out.values_out().iter()
     }
 
-    pub fn values_in(&mut self, id: InputPinId, values: &crate::values::Values) {
-        if id.0 >= Self::inputs() {
-            return;
-        }
-
-        match id.0 {
-            0 => Self::values_in_inner(&mut self.x_in, values),
-            1 => Self::values_in_inner(&mut self.y_in, values),
-            _ => unreachable!(),
-        }
-    }
     fn values_in_inner(pin: &mut InputPin<f64>, values: &crate::values::Values) {
         match values {
             crate::values::Values::Int(values) => pin.values_in(values.iter().map(|v| *v as f64)),
             crate::values::Values::Float(values) => pin.values_in(values.iter().map(|v| *v)),
             _ => unreachable!(),
         }
-    }
-    pub fn values_out(&self) -> Values {
-        Values::Point(self.point_out.values_out().clone())
     }
 }
 
@@ -100,6 +86,18 @@ impl super::InputNode<super::Nodes> for PointNode {
             _ => unreachable!(),
         }
     }
+
+    fn values_in(&mut self, id: InputPinId, values: &Values) {
+        if id.0 >= Self::inputs() {
+            return;
+        }
+
+        match id.0 {
+            0 => Self::values_in_inner(&mut self.x_in, values),
+            1 => Self::values_in_inner(&mut self.y_in, values),
+            _ => unreachable!(),
+        }
+    }
 }
 
 impl super::OutputNode<super::Nodes> for PointNode {
@@ -111,5 +109,9 @@ impl super::OutputNode<super::Nodes> for PointNode {
     ) -> egui_snarl::ui::PinInfo {
         ui.label("Point");
         PinInfo::circle().with_fill(crate::POINT_COLOR)
+    }
+
+    fn values_out(&self, id: crate::pins::OutputPinId) -> Values {
+        Values::Point(self.point_out.values_out().clone())
     }
 }

--- a/src/nodes/point.rs
+++ b/src/nodes/point.rs
@@ -1,6 +1,6 @@
 use egui_snarl::ui::PinInfo;
 
-use crate::pins::{IPin, InputPin, OPin, OutputPin};
+use crate::pins::{IPin, InputPin, InputPinId, OPin, OutputPin};
 
 #[derive(serde::Serialize, serde::Deserialize, Default)]
 pub struct PointNode {
@@ -9,16 +9,6 @@ pub struct PointNode {
     point_out: OutputPin<piet::kurbo::Point>,
 }
 
-/// TODO:
-/// I think showing inputs and outputs should not
-/// be the place where we recalc the node, but rather when
-/// we pull values from it, since recalculation
-/// could be forgotten in the inputs.
-/// I'm missing a general function in egui_snarl
-/// to call once per node...
-/// Maybe it's already time to create a custom solver
-/// That iterates the whole snarl back to front and makes
-/// sure to calculate all node values...
 impl PointNode {
     fn recalc(&mut self) {
         let x = self.x_in.values_out();

--- a/src/nodes/point.rs
+++ b/src/nodes/point.rs
@@ -22,16 +22,10 @@ impl PointNode {
     fn needs_recalc(&self) -> bool {
         self.x_in.is_dirty() || self.y_in.is_dirty()
     }
-    pub fn point_out(&mut self) -> piet::kurbo::Point {
-        if self.needs_recalc() {
-            self.recalc();
-        }
+    pub fn point_out(&self) -> piet::kurbo::Point {
         self.point_out.value_out().map(|pt| *pt).unwrap_or_default()
     }
-    pub fn points_out(&mut self) -> impl Iterator<Item = &piet::kurbo::Point> {
-        if self.needs_recalc() {
-            self.recalc()
-        }
+    pub fn points_out(&self) -> impl Iterator<Item = &piet::kurbo::Point> {
         self.point_out.values_out().iter()
     }
 }

--- a/src/nodes/range.rs
+++ b/src/nodes/range.rs
@@ -1,22 +1,34 @@
 use egui_snarl::ui::PinInfo;
 
-use crate::nodes::NodeDowncast;
+use crate::{
+    nodes::NodeDowncast,
+    pins::{IPin, InputPin, OPin, OutputPin},
+};
 
 use super::{InputNode, NodeInfo, Nodes};
 
 #[derive(serde::Deserialize, serde::Serialize)]
 pub struct RangeNode {
-    start: f64,
-    step: f64,
-    pub(crate) count: usize,
+    start_in: InputPin<f64>,
+    step_in: InputPin<f64>,
+    pub(crate) count_in: InputPin<usize>,
+    range_out: OutputPin<f64>,
 }
 
 impl RangeNode {
-    pub fn get_numbers(&self) -> impl Iterator<Item = f64> + '_ {
-        (0..self.count).map(|i| self.start + self.step * i as f64)
+    pub fn recalc(&mut self) {
+        let start = self.start_in.value_out().copied().unwrap_or_default();
+        let step = self.step_in.value_out().copied().unwrap_or_default();
+        let count = self.count_in.value_out().copied().unwrap_or_default();
+        self.range_out
+            .values_in((0..count).map(|i| start + step * i as f64));
     }
     pub fn values_out(&self) -> crate::values::Values {
-        crate::values::Values::Float(self.get_numbers().collect::<Vec<_>>())
+        crate::values::Values::Float(self.range_out.values_out().clone())
+    }
+
+    pub fn get_numbers(&self) -> impl Iterator<Item = &f64> {
+        self.range_out.values_out().iter()
     }
 }
 /// Need to get fancy, since the node is stored
@@ -51,9 +63,10 @@ impl super::NodeDowncast for RangeNode {
 impl Default for RangeNode {
     fn default() -> Self {
         Self {
-            start: 0.0,
-            step: 1.0,
-            count: 10,
+            start_in: InputPin::default(),
+            step_in: InputPin::default(),
+            count_in: InputPin::default(),
+            range_out: OutputPin::default(),
         }
     }
 }
@@ -78,8 +91,8 @@ fn show_start_input(
     scale: f32,
     snarl: &mut egui_snarl::Snarl<Nodes>,
 ) -> PinInfo {
-    super::show_number_input("Start", pin, ui, scale, snarl, |id, snarl| {
-        &mut get_node_mut(snarl, id).start
+    super::show_input_for_number_pin("Start", pin, ui, scale, snarl, |id, snarl| {
+        &mut get_node_mut(snarl, id).start_in
     })
 }
 
@@ -89,8 +102,8 @@ fn show_step_input(
     scale: f32,
     snarl: &mut egui_snarl::Snarl<Nodes>,
 ) -> PinInfo {
-    super::show_number_input("Step", pin, ui, scale, snarl, |id, snarl| {
-        &mut get_node_mut(snarl, id).step
+    super::show_input_for_number_pin("Step", pin, ui, scale, snarl, |id, snarl| {
+        &mut get_node_mut(snarl, id).step_in
     })
 }
 
@@ -100,26 +113,9 @@ fn show_count_input(
     scale: f32,
     snarl: &mut egui_snarl::Snarl<Nodes>,
 ) -> PinInfo {
-    let info: PinInfo;
-    ui.label("Count");
-    match &*pin.remotes {
-        [] => {
-            ui.add(egui::DragValue::new(&mut get_node_mut(snarl, pin.id).count));
-            info = PinInfo::square().with_fill(crate::UNCONNECTED_COLOR);
-        }
-        [remote] => {
-            if let Some(value) = snarl[remote.node].try_get_float() {
-                get_node_mut(snarl, pin.id).count = value as usize;
-                ui.label(super::format_float(value));
-                info = PinInfo::square().with_fill(crate::NUMBER_COLOR);
-            } else {
-                ui.add(egui::DragValue::new(&mut get_node_mut(snarl, pin.id).count));
-                info = PinInfo::square().with_fill(crate::UNCONNECTED_COLOR);
-            }
-        }
-        _ => unreachable!(),
-    }
-    info
+    super::show_input_for_number_pin("Count", pin, ui, scale, snarl, |id, snarl| {
+        &mut get_node_mut(snarl, id).count_in
+    })
 }
 
 impl InputNode<Nodes> for RangeNode {

--- a/src/nodes/range.rs
+++ b/src/nodes/range.rs
@@ -23,10 +23,6 @@ impl RangeNode {
         self.range_out
             .values_in((0..count).map(|i| start + step * i as f64));
     }
-    pub fn values_out(&self) -> crate::values::Values {
-        crate::values::Values::Float(self.range_out.values_out().clone())
-    }
-
     pub fn get_numbers(&self) -> impl Iterator<Item = &f64> {
         self.range_out.values_out().iter()
     }
@@ -147,6 +143,10 @@ impl InputNode<Nodes> for RangeNode {
         );
         PinInfo::square().with_fill(crate::NUMBER_COLOR)
     }
+
+    fn values_in(&mut self, id: crate::pins::InputPinId, values: &crate::values::Values) {
+        todo!()
+    }
 }
 
 impl super::OutputNode<super::Nodes> for RangeNode {
@@ -157,5 +157,9 @@ impl super::OutputNode<super::Nodes> for RangeNode {
         snarl: &mut egui_snarl::Snarl<super::Nodes>,
     ) -> PinInfo {
         PinInfo::square().with_fill(crate::NUMBER_COLOR)
+    }
+
+    fn values_out(&self, id: crate::pins::OutputPinId) -> crate::values::Values {
+        crate::values::Values::Float(self.range_out.values_out().clone())
     }
 }

--- a/src/nodes/range.rs
+++ b/src/nodes/range.rs
@@ -8,7 +8,7 @@ use super::{InputNode, NodeInfo, Nodes};
 pub struct RangeNode {
     start: f64,
     step: f64,
-    count: usize,
+    pub(crate) count: usize,
 }
 
 impl RangeNode {

--- a/src/nodes/range.rs
+++ b/src/nodes/range.rs
@@ -15,6 +15,9 @@ impl RangeNode {
     pub fn get_numbers(&self) -> impl Iterator<Item = f64> + '_ {
         (0..self.count).map(|i| self.start + self.step * i as f64)
     }
+    pub fn values_out(&self) -> crate::values::Values {
+        crate::values::Values::Float(self.get_numbers().collect::<Vec<_>>())
+    }
 }
 /// Need to get fancy, since the node is stored
 /// inside of the snarl, so if we bind it to a variable

--- a/src/nodes/repeat.rs
+++ b/src/nodes/repeat.rs
@@ -1,74 +1,74 @@
-use egui_snarl::ui::PinInfo;
+// use egui_snarl::ui::PinInfo;
 
-use crate::shapes::Shapes;
+// use crate::shapes::Shapes;
 
-#[derive(serde::Serialize, serde::Deserialize, Default)]
-pub struct RepeatShapeNode {
-    shape: Shapes,
-    count: f64,
-}
+// #[derive(serde::Serialize, serde::Deserialize, Default)]
+// pub struct RepeatShapeNode {
+//     shape: Shapes,
+//     count: f64,
+// }
 
-impl super::Node for RepeatShapeNode {}
-impl super::NodeInfo for RepeatShapeNode {
-    fn inputs() -> usize {
-        2
-    }
+// impl super::Node for RepeatShapeNode {}
+// impl super::NodeInfo for RepeatShapeNode {
+//     fn inputs() -> usize {
+//         2
+//     }
 
-    fn outputs() -> usize {
-        1
-    }
+//     fn outputs() -> usize {
+//         1
+//     }
 
-    fn title() -> String {
-        "RepeatShape".to_string()
-    }
-}
-impl super::NodeDowncast for RepeatShapeNode {
-    fn try_downcast(from: &super::Nodes) -> Option<&Self> {
-        todo!()
-    }
+//     fn title() -> String {
+//         "RepeatShape".to_string()
+//     }
+// }
+// impl super::NodeDowncast for RepeatShapeNode {
+//     fn try_downcast(from: &super::Nodes) -> Option<&Self> {
+//         todo!()
+//     }
 
-    fn try_downcast_mut(from: &mut super::Nodes) -> Option<&mut Self> {
-        match from {
-            super::Nodes::RepeatShape(node) => Some(node),
-            _ => None,
-        }
-    }
-}
-impl super::InputNode<super::Nodes> for RepeatShapeNode {
-    fn show_input(
-        pin: &egui_snarl::InPin,
-        ui: &mut egui::Ui,
-        scale: f32,
-        snarl: &mut egui_snarl::Snarl<super::Nodes>,
-    ) -> egui_snarl::ui::PinInfo {
-        match pin.id.input {
-            0 => super::show_shape_input("Shape", pin, ui, scale, snarl, |id, snarl| {
-                &mut super::get_node_mut::<Self>(snarl, id.node).shape
-            }),
-            1 => super::show_number_input("Count", pin, ui, scale, snarl, |id, snarl| {
-                &mut super::get_node_mut::<Self>(snarl, id.node).count
-            }),
-            _ => unreachable!(),
-        }
-    }
-}
-impl super::OutputNode<super::Nodes> for RepeatShapeNode {
-    fn show_output(
-        pin: &egui_snarl::OutPin,
-        ui: &mut egui::Ui,
-        scale: f32,
-        snarl: &mut egui_snarl::Snarl<super::Nodes>,
-    ) -> egui_snarl::ui::PinInfo {
-        ui.label("Shapes");
-        PinInfo::triangle().with_fill(crate::SHAPE_COLOR)
-    }
-}
-impl super::EmitterNode<Shapes> for RepeatShapeNode {
-    fn value_out(&self) -> Shapes {
-        self.shape.clone()
-    }
+//     fn try_downcast_mut(from: &mut super::Nodes) -> Option<&mut Self> {
+//         match from {
+//             super::Nodes::RepeatShape(node) => Some(node),
+//             _ => None,
+//         }
+//     }
+// }
+// impl super::InputNode<super::Nodes> for RepeatShapeNode {
+//     fn show_input(
+//         pin: &egui_snarl::InPin,
+//         ui: &mut egui::Ui,
+//         scale: f32,
+//         snarl: &mut egui_snarl::Snarl<super::Nodes>,
+//     ) -> egui_snarl::ui::PinInfo {
+//         match pin.id.input {
+//             0 => super::show_shape_input("Shape", pin, ui, scale, snarl, |id, snarl| {
+//                 &mut super::get_node_mut::<Self>(snarl, id.node).shape
+//             }),
+//             1 => super::show_number_input("Count", pin, ui, scale, snarl, |id, snarl| {
+//                 &mut super::get_node_mut::<Self>(snarl, id.node).count
+//             }),
+//             _ => unreachable!(),
+//         }
+//     }
+// }
+// impl super::OutputNode<super::Nodes> for RepeatShapeNode {
+//     fn show_output(
+//         pin: &egui_snarl::OutPin,
+//         ui: &mut egui::Ui,
+//         scale: f32,
+//         snarl: &mut egui_snarl::Snarl<super::Nodes>,
+//     ) -> egui_snarl::ui::PinInfo {
+//         ui.label("Shapes");
+//         PinInfo::triangle().with_fill(crate::SHAPE_COLOR)
+//     }
+// }
+// impl super::EmitterNode<Shapes> for RepeatShapeNode {
+//     fn value_out(&self) -> Shapes {
+//         self.shape.clone()
+//     }
 
-    fn values_out(&self) -> impl Iterator<Item = Shapes> + '_ {
-        (0..self.count as usize).map(|_| self.shape.clone())
-    }
-}
+//     fn values_out(&self) -> impl Iterator<Item = Shapes> + '_ {
+//         (0..self.count as usize).map(|_| self.shape.clone())
+//     }
+// }

--- a/src/nodes/sink.rs
+++ b/src/nodes/sink.rs
@@ -54,7 +54,7 @@ pub fn show_input(pin: &InPin, ui: &mut Ui, scale: f32, snarl: &mut Snarl<Nodes>
                 PinInfo::circle().with_fill(crate::POINT_COLOR)
             }
             Nodes::Circle(node) => {
-                ui.label(format!("{:?}", node.circle_out()));
+                ui.label(format!("{:?}", node.shapes_out().next()));
                 PinInfo::triangle().with_fill(crate::SHAPE_COLOR)
             }
             _ => unreachable!(),

--- a/src/nodes/sink.rs
+++ b/src/nodes/sink.rs
@@ -43,7 +43,7 @@ pub fn show_input(pin: &InPin, ui: &mut Ui, scale: f32, snarl: &mut Snarl<Nodes>
                     .show(ui, |ui| {
                         ui.with_layout(egui::Layout::top_down(egui::Align::LEFT), |ui| {
                             for number in node.get_numbers() {
-                                ui.label(super::format_float(number));
+                                ui.label(super::format_float(*number));
                             }
                         })
                     });

--- a/src/pins/mod.rs
+++ b/src/pins/mod.rs
@@ -1,6 +1,6 @@
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 pub struct InputPinId(pub usize);
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 pub struct OutputPinId(pub usize);
 #[derive(Default, serde::Serialize, serde::Deserialize)]
 pub struct InputPin<T> {
@@ -23,6 +23,10 @@ pub struct OutputPin<T> {
 impl<T> OutputPin<T> {
     pub fn is_dirty(&self) -> bool {
         self.data.is_dirty
+    }
+
+    pub fn get_values(&self) -> crate::values::Values {
+        todo!()
     }
 }
 

--- a/src/pins/mod.rs
+++ b/src/pins/mod.rs
@@ -1,7 +1,7 @@
 #[derive(Default)]
-pub struct InputPinId(usize);
+pub struct InputPinId(pub usize);
 #[derive(Default)]
-pub struct OutputPinId(usize);
+pub struct OutputPinId(pub usize);
 #[derive(Default, serde::Serialize, serde::Deserialize)]
 pub struct InputPin<T> {
     // id: InputPinId,

--- a/src/pins/mod.rs
+++ b/src/pins/mod.rs
@@ -128,6 +128,16 @@ where
     }
 }
 
+/// TODO: Make inputs and outputs their own collections,
+/// so we can impl the draw methods on them directly using new traits
+/// and simplify/fast-forward implementations at the node level
+/// The problem with that is, that the pins are generic over their
+/// type, so we need to wrap them in a non-generic trait, so we
+/// can store them together in a backing array
+// pub struct Inputs<N: const usize> {
+//     pins: [InputPin<?>; N]
+// }
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -1,4 +1,4 @@
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub enum Shapes {
     Circle(piet::kurbo::Circle),
 }

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -285,7 +285,10 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::nodes::{point::PointNode, range::RangeNode, NodeDowncast};
+    use crate::{
+        nodes::{point::PointNode, range::RangeNode, NodeDowncast},
+        pins::IPin,
+    };
 
     use super::*;
 
@@ -359,7 +362,8 @@ mod test {
 
         RangeNode::try_downcast_mut(snarl.get_node_mut(range_id).unwrap())
             .unwrap()
-            .count = 10;
+            .count_in
+            .value_in(10u8);
 
         assert_eq!(
             0,

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -1,0 +1,201 @@
+use std::collections::HashMap;
+
+use crate::{
+    nodes::Nodes,
+    pins::{InputPinId, OutputPinId},
+};
+
+/// TODO: There should be 2 parts of the solver
+/// 1. The `Marker`, traverses the subgraph of changes
+/// starting from the first changed node and marks all
+/// downstream nodes as changed by flagging their inputd
+/// as dirty. It also collects information about the rank
+/// of each visited node measured from the starting node
+/// and returns that at the end of the marking operation.
+/// 2. The `Solver`, traverses the subgraph of changes
+/// one rank at a time. This way it is guaranteed we are
+/// never computing a node value, which would need to still
+/// gather inputs from upstream nodes. After computing a node,
+/// All inputs on the node have to be flagged as clean again
+/// to prepare for the next solve.
+/// Also marker and solver need to operate on the exact same nodestore
+/// so we can leave out some internal bounds check, as every marked
+/// node also will have to be computed at the change step.
+/// For this to work the api needs to take an exclusive reference
+/// to a node store and run the whole solving pipeline at once.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct NodeId(usize);
+
+struct NodeStoreRef<'a, T>
+where
+    T: std::ops::Index<NodeId, Output = Nodes>,
+{
+    inner: &'a T,
+}
+
+impl<'a, T> NodeStoreRef<'a, T>
+where
+    T: std::ops::Index<NodeId, Output = Nodes>,
+{
+    pub fn downstream_node(&self, out_id: OutputPinId) -> Option<NodeId> {
+        todo!()
+    }
+}
+
+struct NodeStoreMut<'a, T>
+where
+    T: std::ops::IndexMut<NodeId, Output = Nodes>,
+{
+    inner: &'a mut T,
+}
+
+// This mapping should ideally move to some conversion layer
+impl<'a> std::ops::Index<NodeId> for egui_snarl::Snarl<Nodes> {
+    type Output = Nodes;
+
+    fn index(&self, index: NodeId) -> &Self::Output {
+        todo!()
+    }
+}
+impl<'a> std::ops::IndexMut<NodeId> for egui_snarl::Snarl<Nodes> {
+    fn index_mut(&mut self, index: NodeId) -> &mut Self::Output {
+        todo!()
+    }
+}
+impl<'a> From<&'a egui_snarl::Snarl<Nodes>> for NodeStoreRef<'a, egui_snarl::Snarl<Nodes>> {
+    fn from(value: &'a egui_snarl::Snarl<Nodes>) -> Self {
+        todo!()
+    }
+}
+impl<'a> From<egui_snarl::Snarl<Nodes>> for NodeStoreRef<'a, egui_snarl::Snarl<Nodes>> {
+    fn from(value: egui_snarl::Snarl<Nodes>) -> Self {
+        todo!()
+    }
+}
+impl<'a> From<&'a mut egui_snarl::Snarl<Nodes>> for NodeStoreMut<'a, egui_snarl::Snarl<Nodes>> {
+    fn from(value: &'a mut egui_snarl::Snarl<Nodes>) -> Self {
+        todo!()
+    }
+}
+impl<'a> From<egui_snarl::Snarl<Nodes>> for NodeStoreMut<'a, egui_snarl::Snarl<Nodes>> {
+    fn from(value: egui_snarl::Snarl<Nodes>) -> Self {
+        todo!()
+    }
+}
+
+struct Marker {
+    ranks: HashMap<usize, Vec<NodeId>>,
+    rank_by_node: HashMap<NodeId, usize>,
+}
+
+impl Marker {
+    pub fn new() -> Self {
+        Self {
+            ranks: HashMap::new(),
+            rank_by_node: HashMap::new(),
+        }
+    }
+
+    fn mark_nodes_from<'a, T>(&mut self, store: &T, node_id: NodeId)
+    where
+        T: std::ops::Index<NodeId, Output = Nodes> + 'a,
+    {
+        let store = NodeStoreRef { inner: store };
+        self.mark_node_inner(&store, node_id, 0);
+    }
+
+    fn mark_node_inner<'a, T>(&mut self, store: &NodeStoreRef<'_, T>, node_id: NodeId, rank: usize)
+    where
+        T: std::ops::Index<NodeId, Output = Nodes> + 'a,
+    {
+        self.store_node_rank(node_id, rank);
+
+        let node = &store.inner[node_id];
+        for out_pin_id in node.out_ids() {
+            if let Some(downstream) = &store.downstream_node(out_pin_id) {
+                self.mark_node_inner(store, *downstream, rank + 1)
+            }
+        }
+    }
+
+    /// Ranks are unique per node and monotonically increasing, so if a node
+    /// is already stored for a lower rank, it will be removed
+    /// from that rank and stored at the higher rank instead
+    fn store_node_rank(&mut self, node_id: NodeId, rank: usize) {
+        // Check if the node has already been assigned to a rank before
+        if self.rank_by_node.contains_key(&node_id) {
+            // Remove the node from the lower rank
+            let old_rank = self.rank_by_node[&node_id];
+            self.ranks.entry(old_rank).and_modify(|rank_nodes| {
+                rank_nodes.remove(
+                    rank_nodes
+                        .iter()
+                        .position(|id| *id == node_id)
+                        .expect("Checked inclusion"),
+                );
+            });
+            self.rank_by_node.remove(&node_id);
+        }
+        // Insert into the ranks tables
+        self.ranks
+            .entry(rank)
+            .and_modify(|nodes| nodes.push(node_id))
+            .or_insert(vec![node_id]);
+        self.rank_by_node.insert(node_id, rank);
+    }
+
+    pub fn get_rank(&self, node_id: NodeId) -> Option<usize> {
+        self.rank_by_node.get(&node_id).copied()
+    }
+}
+
+pub struct Solver {
+    nodes_ids: Vec<NodeId>,
+    connections: Vec<OutgoingConnections>,
+    dirty_ranks: HashMap<usize, Vec<NodeId>>,
+    dirty_ranks_by_node: HashMap<NodeId, usize>,
+}
+
+impl Solver {}
+
+struct OutgoingConnections {
+    node_id: NodeId,
+    pin_id: OutputPinId,
+}
+
+impl OutgoingConnections {
+    fn get_connections<'a, S, T>(&self, store: &S) -> impl Iterator<Item = (NodeId, InputPinId)>
+    where
+        S: Into<NodeStoreRef<'a, T>>,
+        T: std::ops::Index<NodeId, Output = Nodes> + 'a,
+    {
+        (0..1).into_iter().map(|_| (NodeId(0), InputPinId(0)))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_api() {
+        let mut snarl: egui_snarl::Snarl<Nodes> = egui_snarl::Snarl::new();
+        // Solver::mark_node_for_solve(&mut snarl, NodeId(0));
+        let connections = OutgoingConnections {
+            node_id: todo!(),
+            pin_id: todo!(),
+        };
+        connections.get_connections(&snarl);
+    }
+
+    #[test]
+    fn noderanks_should_increase_on_conflict() {
+        let mut marker = Marker::new();
+        let id = NodeId(0);
+        marker.store_node_rank(id, 0);
+        assert_eq!(0, marker.get_rank(id).unwrap());
+        marker.store_node_rank(id, 3);
+        assert_eq!(3, marker.get_rank(id).unwrap());
+    }
+}

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -192,8 +192,6 @@ impl Marker {
         let node = &store.inner[node_id];
         for out_pin_id in node.out_ids() {
             for (downstream_node, _) in store.inner.get_downstream_inputs(node_id, out_pin_id) {
-                // TODO: Use the input pin id info here to mark
-                // the actual input that needs to recompute
                 self.mark_node_inner(store, downstream_node, rank + 1)
             }
         }
@@ -236,6 +234,10 @@ impl Marker {
     }
 }
 
+/// Solve a subgraph of nodes of the given [`T`] store
+/// starting from the given node id. All nodes which are direct
+/// children of the start node will be solved and subsequently alser
+/// trigger solving of their children
 pub fn solve_starting_from<'a, T>(node_id: NodeId, store: &mut T)
 where
     T: std::ops::IndexMut<NodeId, Output = Nodes> + DownStreamTopology + 'a,
@@ -277,7 +279,7 @@ where
             }
             let output = &store[id].values_out(out_id);
             for (node_id, in_id) in in_ids.into_iter() {
-                &mut store[node_id].push_inputs(in_id, output);
+                &mut store[node_id].values_in(in_id, output);
             }
         }
     }

--- a/src/values.rs
+++ b/src/values.rs
@@ -25,6 +25,7 @@ pub enum Values {
     Float(Vec<f64>),
     String(Vec<String>),
     Bool(Vec<bool>),
+    Point(Vec<piet::kurbo::Point>),
     Custom(Vec<Box<dyn Any>>),
     // TODO: How can we allow custom types here? Box<dyn Any>?
     // Custom(Vec<T>),

--- a/src/values.rs
+++ b/src/values.rs
@@ -1,0 +1,50 @@
+use std::any::{Any, TypeId};
+
+use crate::pins::{IPin, InputPin, OPin, OutputPin};
+
+/// Using a value enum is potentially quite wasteful,
+/// as all variants will be 64 bits and we will have to pattern match
+/// on the values inside of the iterator. This is quite a lot of
+/// overhead, which I'm not sure I love...
+/// I would love an api like
+/// ```
+/// let output = node.values_out(out_id);
+/// other_node.values_in(in_id);
+/// ```
+/// where both `values_out` and `values_in` are generic over some
+/// type `T`. There is no way to name that type for unknown nodes
+/// though, so I think going for a value enum (which we can name)
+/// is the correct approach for now. So the signature becomes:
+/// ```
+/// fn values_out(&self) -> Values {todo!()}
+/// ```
+///
+pub enum Values {
+    /// Maybe this should be u64 instead...
+    Int(Vec<usize>),
+    Float(Vec<f64>),
+    String(Vec<String>),
+    Bool(Vec<bool>),
+    Custom(Vec<Box<dyn Any>>),
+    // TODO: How can we allow custom types here? Box<dyn Any>?
+    // Custom(Vec<T>),
+    // CustomRef(Vec<Box<T>>),
+}
+
+fn pipe_values_into<P, C>(producer: &OutputPin<P>, consumer: &mut InputPin<C>)
+where
+    P: Clone,
+    C: From<P> + PartialEq,
+{
+    consumer.values_in(producer.values_out().into_iter().cloned());
+}
+
+pub trait ValuePipe<T> {
+    fn pipe_values_into(&self, pin: &mut InputPin<T>);
+}
+
+impl<T> ValuePipe<T> for OutputPin<T> {
+    fn pipe_values_into(&self, pin: &mut InputPin<T>) {
+        todo!()
+    }
+}

--- a/src/values.rs
+++ b/src/values.rs
@@ -20,12 +20,14 @@ use crate::pins::{IPin, InputPin, OPin, OutputPin};
 /// ```
 ///
 pub enum Values {
-    /// Maybe this should be u64 instead...
-    Int(Vec<usize>),
+    /// This is a u32, since u32 and f64 can be converted into eachother
+    Int(Vec<u32>),
     Float(Vec<f64>),
     String(Vec<String>),
     Bool(Vec<bool>),
     Point(Vec<piet::kurbo::Point>),
+    Circle(Vec<piet::kurbo::Circle>),
+    Shape(Vec<crate::shapes::Shapes>),
     Custom(Vec<Box<dyn Any>>),
     // TODO: How can we allow custom types here? Box<dyn Any>?
     // Custom(Vec<T>),
@@ -38,14 +40,4 @@ where
     C: From<P> + PartialEq,
 {
     consumer.values_in(producer.values_out().into_iter().cloned());
-}
-
-pub trait ValuePipe<T> {
-    fn pipe_values_into(&self, pin: &mut InputPin<T>);
-}
-
-impl<T> ValuePipe<T> for OutputPin<T> {
-    fn pipe_values_into(&self, pin: &mut InputPin<T>) {
-        todo!()
-    }
 }

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -46,9 +46,6 @@ impl SnarlViewer<nodes::Nodes> for NodeGraphViewer {
             nodes::Nodes::Point(_) => nodes::point::PointNode::show_input(pin, ui, scale, snarl),
             nodes::Nodes::Circle(_) => nodes::circle::CircleNode::show_input(pin, ui, scale, snarl),
             nodes::Nodes::Canvas(_) => nodes::canvas::CanvasNode::show_input(pin, ui, scale, snarl),
-            nodes::Nodes::RepeatShape(_) => {
-                nodes::repeat::RepeatShapeNode::show_input(pin, ui, scale, snarl)
-            }
         }
     }
 
@@ -69,9 +66,6 @@ impl SnarlViewer<nodes::Nodes> for NodeGraphViewer {
             }
             nodes::Nodes::Canvas(_) => {
                 nodes::canvas::CanvasNode::show_output(pin, ui, scale, snarl)
-            }
-            nodes::Nodes::RepeatShape(_) => {
-                nodes::repeat::RepeatShapeNode::show_output(pin, ui, scale, snarl)
             }
         }
     }
@@ -129,13 +123,6 @@ impl SnarlViewer<nodes::Nodes> for NodeGraphViewer {
             snarl.insert_node(
                 pos,
                 nodes::Nodes::Canvas(nodes::canvas::CanvasNode::default()),
-            );
-            ui.close_menu();
-        }
-        if ui.button("RepeatShape").clicked() {
-            snarl.insert_node(
-                pos,
-                nodes::Nodes::RepeatShape(nodes::repeat::RepeatShapeNode::default()),
             );
             ui.close_menu();
         }


### PR DESCRIPTION
Implement a simple graph solver MVP, which can solve the whole nodegraph on every change.

This PR is lacking the full implementation for some nodes, as well as generally having some rough edges, but I consider it *good enough* for it to be merged into develop. Next up I should definitely implement a proper trait for all nodes and maybe already switch of the known `Nodes` enum towards dynamic dispatch. As the goal in the future is to allow users to define their own nodes, the enum approach will never be able to handle that. Also there is a lot of cloning, which could probably be removed by rethinking the exact borrow semantics of values being passed betwen nodes